### PR TITLE
Set up release build flow.

### DIFF
--- a/.cloudbuild/release.yaml
+++ b/.cloudbuild/release.yaml
@@ -1,0 +1,7 @@
+steps:
+- name: 'gcr.io/cloud-builders/gradle:5.6.2-jdk-8'
+  args: ['--stacktrace', '-Pprefab.release', 'release']
+artifacts:
+  objects:
+    location: 'gs://$_ARTIFACT_BUCKET/$PROJECT_ID/$TAG_NAME'
+    paths: ['build/distributions/*.zip']

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -40,7 +40,11 @@ repositories {
 
 subprojects {
     group = "com.google.prefab"
-    version = "0.1.0"
+    version = "1.0.0" + if (!rootProject.hasProperty("prefab.release")) {
+        "-SNAPSHOT"
+    } else {
+        ""
+    }
 
     apply(plugin = "org.jetbrains.kotlin.jvm")
     apply(plugin = "kotlinx-serialization")
@@ -125,4 +129,9 @@ tasks.named("repositoryDistTar") {
 
 tasks.named("repositoryDistZip") {
     subprojects.map { dependsOn(":${it.name}:publish") }
+}
+
+tasks.register("release") {
+    dependsOn(":build")
+    dependsOn(":dokka")
 }


### PR DESCRIPTION
Change the current version built by default to 1.0.0-SNAPSHOT and
configure a "release" task. The release task requires the tag name
that's passed to the project via CI, which will be used as the version
string for that build.

This also causes dokka to run. I'm not currently archiving those
results because I'm not sure about the best way to get those onto our
docs page yet, but that's something we should do.