### PR TITLE
Tone down type inference inspection.

### DIFF
--- a/.idea/inspectionProfiles/Project_Default.xml
+++ b/.idea/inspectionProfiles/Project_Default.xml
@@ -14,10 +14,7 @@
     <inspection_tool class="MoveSuspiciousCallableReferenceIntoParentheses" enabled="true" level="WARNING" enabled_by_default="true" />
     <inspection_tool class="PackageDirectoryMismatch" enabled="true" level="WARNING" enabled_by_default="true" />
     <inspection_tool class="ProblematicWhitespace" enabled="true" level="WARNING" enabled_by_default="true" />
-    <inspection_tool class="PublicApiImplicitType" enabled="true" level="WARNING" enabled_by_default="true">
-      <option name="reportInternal" value="true" />
-      <option name="reportPrivate" value="true" />
-    </inspection_tool>
+    <inspection_tool class="PublicApiImplicitType" enabled="true" level="WARNING" enabled_by_default="true" />
     <inspection_tool class="SuspiciousEqualsCombination" enabled="true" level="WARNING" enabled_by_default="true" />
     <inspection_tool class="UnsafeCastFromDynamic" enabled="true" level="WARNING" enabled_by_default="true" />
     <inspection_tool class="WrapUnaryOperator" enabled="true" level="WARNING" enabled_by_default="true" />


### PR DESCRIPTION
Keep requiring explicit types on public APIs to avoid accidental API
changes, but don't require it for private or internal APIs.

/gcbrun