### PR TITLE
Make the CLI a fat jar.

### DIFF
--- a/cli/build.gradle.kts
+++ b/cli/build.gradle.kts
@@ -39,4 +39,10 @@ tasks.withType<Jar> {
     manifest {
         attributes["Main-Class"] = application.mainClassName
     }
+
+    from(configurations.runtimeClasspath.get().map {
+        if (it.isDirectory) it else zipTree(
+            it
+        )
+    })
 }


### PR DESCRIPTION
Save users and AGP the trouble of finding all the other jars to put on
the classpath.