### PR TITLE
Use the architecture-specific layout for CMake.

### DIFF
--- a/api/src/main/kotlin/com/google/prefab/api/Android.kt
+++ b/api/src/main/kotlin/com/google/prefab/api/Android.kt
@@ -27,9 +27,14 @@ import kotlin.math.max
  * @property[abi] The ABI targeted by this build.
  * @property[api] The Android minSdkVersion targeted by this build.
  * @property[stl] The Android STL targeted by this build.
+ * @property[ndkMajorVersion] The major version of the Android NDK targeted by
+ * this build.
  * @constructor Creates an Android requirements object.
  */
-class Android(val abi: Abi, api: Int, val stl: Stl) : PlatformDataInterface {
+class Android(val abi: Abi, api: Int, val stl: Stl, val ndkMajorVersion: Int) :
+    PlatformDataInterface {
+    override val targetTriple: String = abi.triple
+
     val api: Int = when (abi) {
         Abi.Arm32, Abi.X86 -> api
         Abi.Arm64, Abi.X86_64 -> max(api, 21)
@@ -42,29 +47,33 @@ class Android(val abi: Abi, api: Int, val stl: Stl) : PlatformDataInterface {
      *
      * See https://developer.android.com/ndk/guides/abis for more information.
      *
-     * @param[targetArchAbi] The Android ABI name for this ABI. This matches the
-     * `APP_ABI` ndk-build variable or `ANDROID_ABI` CMake toolchain variable.
+     * @property[targetArchAbi] The Android ABI name for this ABI. This matches
+     * the `APP_ABI` ndk-build variable or `ANDROID_ABI` CMake toolchain
+     * variable.
+     * @property[triple] The target triple associated with this ABI. Note that
+     * this is the library architecture rather than the exact target, so 32-bit
+     * Arm is arm-linux-androideabi rather than armv7a-linux-androideabi.
      */
-    enum class Abi(val targetArchAbi: String) {
+    enum class Abi(val targetArchAbi: String, val triple: String) {
         /**
          * 32-bit Arm.
          */
-        Arm32("armeabi-v7a"),
+        Arm32("armeabi-v7a", "arm-linux-androideabi"),
 
         /**
          * 64-bit Arm.
          */
-        Arm64("arm64-v8a"),
+        Arm64("arm64-v8a", "aarch64-linux-android"),
 
         /**
          * 32-bit x86.
          */
-        X86("x86"),
+        X86("x86", "i686-linux-android"),
 
         /**
          * 64-bit x86.
          */
-        X86_64("x86_64");
+        X86_64("x86_64", "x86_64-linux-android");
 
         companion object {
             /**
@@ -275,7 +284,8 @@ class Android(val abi: Abi, api: Int, val stl: Stl) : PlatformDataInterface {
             return Android(
                 Abi.fromString(metadata.abi),
                 metadata.api,
-                Stl.fromString(metadata.stl)
+                Stl.fromString(metadata.stl),
+                metadata.ndk
             )
         }
     }

--- a/api/src/main/kotlin/com/google/prefab/api/PlatformInterface.kt
+++ b/api/src/main/kotlin/com/google/prefab/api/PlatformInterface.kt
@@ -24,6 +24,15 @@ import java.nio.file.Path
  */
 interface PlatformDataInterface {
     /**
+     * The target triple used for this platform.
+     *
+     * This is used to determine the architecture-specific directory for
+     * installing CMake build scripts, so it must match the platform's
+     * [CMAKE_LIBRARY_ARCHITECTURE](https://cmake.org/cmake/help/latest/variable/CMAKE_LIBRARY_ARCHITECTURE.html).
+     */
+    val targetTriple: String
+
+    /**
      * Determines if the given [library] can be used with this platform.
      *
      * This [PlatformDataInterface] object defines the platform requirements

--- a/api/src/test/kotlin/com/google/prefab/api/AndroidTest.kt
+++ b/api/src/test/kotlin/com/google/prefab/api/AndroidTest.kt
@@ -29,8 +29,8 @@ import kotlin.test.assertTrue
 class AndroidTest {
     @Test
     fun `ABIs must match`() {
-        val arm32 = Android(Android.Abi.Arm32, 21, Android.Stl.CxxShared)
-        val arm64 = Android(Android.Abi.Arm64, 21, Android.Stl.CxxShared)
+        val arm32 = Android(Android.Abi.Arm32, 21, Android.Stl.CxxShared, 21)
+        val arm64 = Android(Android.Abi.Arm64, 21, Android.Stl.CxxShared, 21)
         val arm32Lib = mockk<PrebuiltLibrary>()
         val arm64Lib = mockk<PrebuiltLibrary>()
         every { arm32Lib.platform } returns arm32
@@ -44,8 +44,8 @@ class AndroidTest {
 
     @Test
     fun `OS version constraint only allows equal or older dependencies`() {
-        val old = Android(Android.Abi.Arm32, 16, Android.Stl.CxxShared)
-        val new = Android(Android.Abi.Arm32, 21, Android.Stl.CxxShared)
+        val old = Android(Android.Abi.Arm32, 16, Android.Stl.CxxShared, 21)
+        val new = Android(Android.Abi.Arm32, 21, Android.Stl.CxxShared, 21)
         val oldLib = mockk<PrebuiltLibrary>()
         val newLib = mockk<PrebuiltLibrary>()
         every { oldLib.platform } returns old
@@ -58,11 +58,14 @@ class AndroidTest {
 
     @Test
     fun `STL matching constraints are enforced`() {
-        val cxxShared = Android(Android.Abi.Arm64, 21, Android.Stl.CxxShared)
-        val cxxStatic = Android(Android.Abi.Arm64, 21, Android.Stl.CxxStatic)
-        val gnuShared = Android(Android.Abi.Arm64, 21, Android.Stl.GnustlShared)
-        val none = Android(Android.Abi.Arm64, 21, Android.Stl.None)
-        val system = Android(Android.Abi.Arm64, 21, Android.Stl.System)
+        val cxxShared =
+            Android(Android.Abi.Arm64, 21, Android.Stl.CxxShared, 21)
+        val cxxStatic =
+            Android(Android.Abi.Arm64, 21, Android.Stl.CxxStatic, 21)
+        val gnuShared =
+            Android(Android.Abi.Arm64, 21, Android.Stl.GnustlShared, 21)
+        val none = Android(Android.Abi.Arm64, 21, Android.Stl.None, 21)
+        val system = Android(Android.Abi.Arm64, 21, Android.Stl.System, 21)
 
         // A shared library using c++_shared.
         val cxxSharedSharedLib = mockk<PrebuiltLibrary>()
@@ -152,11 +155,11 @@ class AndroidTest {
     fun `OS version pulled up to 21 for LP64`() {
         assertEquals(
             16,
-            Android(Android.Abi.Arm32, 16, Android.Stl.CxxShared).api
+            Android(Android.Abi.Arm32, 16, Android.Stl.CxxShared, 21).api
         )
         assertEquals(
             21,
-            Android(Android.Abi.Arm64, 16, Android.Stl.CxxShared).api
+            Android(Android.Abi.Arm64, 16, Android.Stl.CxxShared, 21).api
         )
     }
 }

--- a/cli/src/main/kotlin/com/google/prefab/cli/Cli.kt
+++ b/cli/src/main/kotlin/com/google/prefab/cli/Cli.kt
@@ -28,6 +28,7 @@ import com.github.ajalt.clikt.parameters.options.option
 import com.github.ajalt.clikt.parameters.options.required
 import com.github.ajalt.clikt.parameters.types.choice
 import com.github.ajalt.clikt.parameters.types.file
+import com.github.ajalt.clikt.parameters.types.int
 import com.google.prefab.api.Android
 import com.google.prefab.api.Package
 import com.google.prefab.api.PlatformDataInterface
@@ -133,14 +134,21 @@ open class Cli :
         val abi = config.abi
         val osVersion = config.osVersion
         val stl = Android.Stl.fromString(config.stl)
+        val ndkVersion = config.ndkVersion
         if (abi != null) {
             return listOf(
-                Android(Android.Abi.fromString(abi), osVersion.toInt(), stl)
+                Android(
+                    Android.Abi.fromString(abi),
+                    osVersion.toInt(),
+                    stl,
+                    ndkVersion
+                )
             )
         }
 
         // If --abi wasn't provided, build for every ABI.
-        return Android.Abi.values().map { Android(it, osVersion.toInt(), stl) }
+        return Android.Abi.values()
+            .map { Android(it, osVersion.toInt(), stl, ndkVersion) }
     }
 
     private val platformRequirements: Collection<PlatformDataInterface>

--- a/cli/src/main/kotlin/com/google/prefab/cli/Cli.kt
+++ b/cli/src/main/kotlin/com/google/prefab/cli/Cli.kt
@@ -20,7 +20,6 @@ import com.github.ajalt.clikt.core.CliktCommand
 import com.github.ajalt.clikt.core.UsageError
 import com.github.ajalt.clikt.parameters.arguments.argument
 import com.github.ajalt.clikt.parameters.arguments.multiple
-import com.github.ajalt.clikt.parameters.arguments.validate
 import com.github.ajalt.clikt.parameters.groups.OptionGroup
 import com.github.ajalt.clikt.parameters.groups.groupChoice
 import com.github.ajalt.clikt.parameters.groups.required
@@ -80,13 +79,21 @@ class AndroidConfig :
         "stlport_static",
         "system"
     ).required()
+
+    /**
+     * NDK version used by the application.
+     */
+    val ndkVersion: Int by option(
+        help = "Major version of the NDK used by the application."
+    ).int().required()
 }
 
 // Open for testing.
 /**
  * The command line interface for Prefab.
  */
-open class Cli : CliktCommand(help = "prefab") {
+open class Cli :
+    CliktCommand(name = "prefab", help = "https://google.github.io/prefab/") {
     private val buildSystem: String by option(
         help = "Generate integration for the given build system."
     ).required()
@@ -107,9 +114,7 @@ open class Cli : CliktCommand(help = "prefab") {
 
     private val rawPackagePaths: List<File> by argument("PACKAGE_PATH").file(
         fileOkay = false, readable = true
-    ).multiple().validate {
-        require(it.isNotEmpty()) { "must provide at least one package" }
-    }
+    ).multiple(required = true)
 
     /**
      * De-duplicated packages paths.

--- a/cli/src/test/kotlin/com/google/prefab/cli/ArgParserTest.kt
+++ b/cli/src/test/kotlin/com/google/prefab/cli/ArgParserTest.kt
@@ -169,7 +169,7 @@ class ArgParserTest {
 
     @Test
     fun `fails if no packages are provided`() {
-        assertFailsWith(BadParameterValue::class) {
+        assertFailsWith(MissingParameter::class) {
             NoRunTestCli().parse(
                 listOf(
                     "--platform", "android",

--- a/cli/src/test/kotlin/com/google/prefab/cli/ArgParserTest.kt
+++ b/cli/src/test/kotlin/com/google/prefab/cli/ArgParserTest.kt
@@ -143,6 +143,7 @@ class ArgParserTest {
                     "--platform", "android",
                     "--os-version", "21",
                     "--stl", "c++_shared",
+                    "--ndk-version", "21",
                     "--build-system", "ndk-build",
                     "--output", "out",
                     "foo"
@@ -159,6 +160,7 @@ class ArgParserTest {
                     "--platform", "android",
                     "--os-version", "21",
                     "--stl", "c++_shared",
+                    "--ndk-version", "21",
                     "--build-system", "ndk-build",
                     "--output", "out",
                     plug1.path
@@ -175,6 +177,7 @@ class ArgParserTest {
                     "--platform", "android",
                     "--os-version", "21",
                     "--stl", "c++_shared",
+                    "--ndk-version", "21",
                     "--build-system", "ndk-build",
                     "--output", "out"
                 )
@@ -190,6 +193,7 @@ class ArgParserTest {
                 "--abi", "arm64-v8a",
                 "--os-version", "21",
                 "--stl", "c++_shared",
+                "--ndk-version", "21",
                 "--build-system", "ndk-build",
                 "--output", "out",
                 "--plugin-path", plug1.path,
@@ -223,6 +227,7 @@ class ArgParserTest {
                     "--abi", "arm64-v8a",
                     "--os-version", "21",
                     "--stl", "c++_shared",
+                    "--ndk-version", "21",
                     "--build-system", "ndk-build",
                     "--output", "out",
                     packageA.toString(),

--- a/cli/src/test/kotlin/com/google/prefab/cli/EndToEndTest.kt
+++ b/cli/src/test/kotlin/com/google/prefab/cli/EndToEndTest.kt
@@ -43,6 +43,7 @@ class EndToEndTest {
                     "--abi", "arm64-v8a",
                     "--os-version", "21",
                     "--stl", "c++_shared",
+                    "--ndk-version", "21",
                     "--build-system", "ndk-build",
                     "--output", outputDirectory.toString(),
                     packagePath.toString()

--- a/cli/src/test/kotlin/com/google/prefab/cli/ModuleTest.kt
+++ b/cli/src/test/kotlin/com/google/prefab/cli/ModuleTest.kt
@@ -31,7 +31,7 @@ import kotlin.test.assertEquals
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
 class ModuleTest {
     private val android: PlatformDataInterface =
-        Android(Android.Abi.Arm64, 21, Android.Stl.CxxShared)
+        Android(Android.Abi.Arm64, 21, Android.Stl.CxxShared, 21)
 
     @Test
     fun `can load basic module`() {

--- a/cli/src/test/kotlin/com/google/prefab/cli/NdkBuildPluginTest.kt
+++ b/cli/src/test/kotlin/com/google/prefab/cli/NdkBuildPluginTest.kt
@@ -49,7 +49,7 @@ class NdkBuildPluginTest {
     fun `stale files are removed from extant output directory`() {
         assertTrue(staleFile.toFile().exists())
         NdkBuildPlugin(staleOutputDir.toFile(), emptyList()).generate(
-            listOf(Android(Android.Abi.Arm64, 21, Android.Stl.CxxShared))
+            listOf(Android(Android.Abi.Arm64, 21, Android.Stl.CxxShared, 21))
         )
         assertFalse(staleFile.toFile().exists())
     }
@@ -65,7 +65,14 @@ class NdkBuildPluginTest {
         val qux = Package(quxPath)
 
         NdkBuildPlugin(outputDirectory.toFile(), listOf(foo, qux)).generate(
-            Android.Abi.values().map { Android(it, 19, Android.Stl.CxxShared) }
+            Android.Abi.values().map {
+                Android(
+                    it,
+                    19,
+                    Android.Stl.CxxShared,
+                    21
+                )
+            }
         )
 
         val fooAndroidMk = outputDirectory.resolve("foo/Android.mk").toFile()
@@ -248,7 +255,7 @@ class NdkBuildPluginTest {
         val qux = Package(quxPath)
 
         NdkBuildPlugin(outputDirectory.toFile(), listOf(foo, qux)).generate(
-            listOf(Android(Android.Abi.Arm64, 19, Android.Stl.CxxShared))
+            listOf(Android(Android.Abi.Arm64, 19, Android.Stl.CxxShared, 21))
         )
 
         val fooAndroidMk = outputDirectory.resolve("foo/Android.mk").toFile()
@@ -339,7 +346,14 @@ class NdkBuildPluginTest {
                 outputDirectory.toFile(),
                 listOf(moduleA, moduleB)
             ).generate(
-                listOf(Android(Android.Abi.Arm64, 19, Android.Stl.CxxShared))
+                listOf(
+                    Android(
+                        Android.Abi.Arm64,
+                        19,
+                        Android.Stl.CxxShared,
+                        21
+                    )
+                )
             )
         }
     }
@@ -350,7 +364,7 @@ class NdkBuildPluginTest {
             Paths.get(this.javaClass.getResource("packages/header_only").toURI())
         val pkg = Package(packagePath)
         NdkBuildPlugin(outputDirectory.toFile(), listOf(pkg)).generate(
-            listOf(Android(Android.Abi.Arm64, 19, Android.Stl.CxxShared))
+            listOf(Android(Android.Abi.Arm64, 19, Android.Stl.CxxShared, 21))
         )
 
         val androidMk =
@@ -397,7 +411,14 @@ class NdkBuildPluginTest {
         val pkg = Package(path)
 
         NdkBuildPlugin(outputDirectory.toFile(), listOf(pkg)).generate(
-            Android.Abi.values().map { Android(it, 19, Android.Stl.CxxShared) }
+            Android.Abi.values().map {
+                Android(
+                    it,
+                    19,
+                    Android.Stl.CxxShared,
+                    21
+                )
+            }
         )
 
         val androidMk =

--- a/cli/src/test/kotlin/com/google/prefab/cli/PackageTest.kt
+++ b/cli/src/test/kotlin/com/google/prefab/cli/PackageTest.kt
@@ -31,7 +31,7 @@ import kotlin.test.assertFailsWith
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
 class PackageTest {
     private val android: PlatformDataInterface =
-        Android(Android.Abi.Arm64, 21, Android.Stl.CxxShared)
+        Android(Android.Abi.Arm64, 21, Android.Stl.CxxShared, 21)
 
     @Test
     fun `can load basic package`() {

--- a/docs/index.md
+++ b/docs/index.md
@@ -44,6 +44,8 @@ Android specific configuration options:
   --os-version TEXT                Target OS version.
   --stl [c++_shared|c++_static|gnustl_shared|gnustl_static|none|stlport_shared|stlport_static|system]
                                    STL used by the application.
+  --ndk-version INT                Major version of the NDK used by the
+                                   application.
 
 Options:
   --build-system TEXT  Generate integration for the given build system.

--- a/docs/index.md
+++ b/docs/index.md
@@ -37,7 +37,7 @@ TODO: Improve usage message.
 ```text
 Usage: prefab [OPTIONS] PACKAGE_PATH...
 
-  prefab
+  https://google.github.io/prefab/
 
 Android specific configuration options:
   --abi TEXT                       Target ABI.


### PR DESCRIPTION
We can't do this in every case, since old NDKs didn't set the
appropriate value in their toolchain file, but use it where we can.
    
Fixes https://github.com/google/prefab/issues/11

/gcbrun