### PR TITLE
Remove the developers field from the POM.

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -92,11 +92,6 @@ subprojects {
                                 distribution.set("repo")
                             }
                         }
-                        developers {
-                            developer {
-                                name.set("The Android Open Source Project")
-                            }
-                        }
                         scm {
                             connection.set(
                                 "scm:git:https://github.com/google/prefab.git"


### PR DESCRIPTION
This was the wrong group, and from a quick inspection of some other
Google POMs (protobuf and truth) we don't usually set this anyway.

/gcbrun