### PR TITLE
Load build system plugins from the classpath.

### DIFF
--- a/api/src/main/kotlin/com/google/prefab/api/BuildSystemInterface.kt
+++ b/api/src/main/kotlin/com/google/prefab/api/BuildSystemInterface.kt
@@ -21,7 +21,7 @@ import java.io.File
 /**
  * The interface that Prefab uses to create build system plugins.
  */
-interface BuildSystemFactory {
+interface BuildSystemProvider {
     /**
      * An identifier matching the build system.
      *
@@ -48,7 +48,7 @@ interface BuildSystemFactory {
 /**
  * An interface to a build system generator.
  *
- * This, along with the associated [BuildSystemFactory] is the interface that
+ * This, along with the associated [BuildSystemProvider] is the interface that
  * build system plugins implement.
  */
 interface BuildSystemInterface {

--- a/cli/build.gradle.kts
+++ b/cli/build.gradle.kts
@@ -26,8 +26,11 @@ dependencies {
     testImplementation("io.mockk:mockk:1.9.3")
 
     implementation(project(":api"))
-    implementation(project(":cmake-plugin"))
-    implementation(project(":ndk-build-plugin"))
+    runtimeOnly(project(":cmake-plugin"))
+    runtimeOnly(project(":ndk-build-plugin"))
+
+    testImplementation(project(":cmake-plugin"))
+    testImplementation(project(":ndk-build-plugin"))
 }
 
 application {
@@ -45,4 +48,7 @@ tasks.withType<Jar> {
             it
         )
     })
+
+    dependsOn(":cmake-plugin:jar")
+    dependsOn(":ndk-build-plugin:jar")
 }

--- a/cli/src/main/kotlin/com/google/prefab/cli/BuildSystemRegistry.kt
+++ b/cli/src/main/kotlin/com/google/prefab/cli/BuildSystemRegistry.kt
@@ -16,9 +16,8 @@
 
 package com.google.prefab.cli
 
-import com.google.prefab.api.BuildSystemFactory
-import com.google.prefab.cmake.CMakePlugin
-import com.google.prefab.ndkbuild.NdkBuildPlugin
+import com.google.prefab.api.BuildSystemProvider
+import java.util.ServiceLoader
 
 /**
  * A list of known build systems.
@@ -30,8 +29,9 @@ object BuildSystemRegistry {
     /**
      * The list of known build systems.
      */
-    private var buildSystems: List<BuildSystemFactory> =
-        listOf(CMakePlugin, NdkBuildPlugin)
+    private val buildSystems: List<BuildSystemProvider> =
+        ServiceLoader.load(BuildSystemProvider::class.java).iterator()
+            .asSequence().toList()
 
     /**
      * Determines whether or not a build system with the given name is
@@ -53,7 +53,7 @@ object BuildSystemRegistry {
      * @return The build system matching [identifier], or null if there is no
      * match.
      */
-    fun find(identifier: String): BuildSystemFactory? {
+    fun find(identifier: String): BuildSystemProvider? {
         return buildSystems.find { it.identifier == identifier }
     }
 }

--- a/cli/src/main/kotlin/com/google/prefab/cli/Cli.kt
+++ b/cli/src/main/kotlin/com/google/prefab/cli/Cli.kt
@@ -23,7 +23,6 @@ import com.github.ajalt.clikt.parameters.arguments.multiple
 import com.github.ajalt.clikt.parameters.groups.OptionGroup
 import com.github.ajalt.clikt.parameters.groups.groupChoice
 import com.github.ajalt.clikt.parameters.groups.required
-import com.github.ajalt.clikt.parameters.options.multiple
 import com.github.ajalt.clikt.parameters.options.option
 import com.github.ajalt.clikt.parameters.options.required
 import com.github.ajalt.clikt.parameters.types.choice
@@ -102,10 +101,6 @@ open class Cli :
     private val output: File by option(
         help = "Output path for generated build system integration."
     ).file(fileOkay = false).required()
-
-    private val pluginPath: List<File> by option(
-        help = "Path to build system integration plugin."
-    ).file(folderOkay = false, readable = true).multiple()
 
     private val platform: PlatformConfig by option(
         help = "Target platform. Only 'android' is currently supported."

--- a/cli/src/test/kotlin/com/google/prefab/cli/ArgParserTest.kt
+++ b/cli/src/test/kotlin/com/google/prefab/cli/ArgParserTest.kt
@@ -34,11 +34,7 @@ class ArgParserTest {
         }
     }
 
-    private val plug1: File = File.createTempFile("plugin", ".jar").apply {
-        deleteOnExit()
-    }
-
-    private val plug2: File = File.createTempFile("plugin", ".jar").apply {
+    private val file: File = File.createTempFile("tmpfile", null).apply {
         deleteOnExit()
     }
 
@@ -84,37 +80,7 @@ class ArgParserTest {
                 listOf(
                     "--platform", "android",
                     "--build-system", "ndk-build",
-                    "--output", plug1.path,
-                    fooPath.toString()
-                )
-            )
-        }
-    }
-
-    @Test
-    fun `fails if --plugin-path doesn't exist`() {
-        assertFailsWith(BadParameterValue::class) {
-            NoRunTestCli().parse(
-                listOf(
-                    "--platform", "android",
-                    "--build-system", "ndk-build",
-                    "--plugin-path", "bazel-plugin.jar",
-                    "--output", "out",
-                    fooPath.toString()
-                )
-            )
-        }
-    }
-
-    @Test
-    fun `fails if --plugin-path is a directory`() {
-        assertFailsWith(BadParameterValue::class) {
-            NoRunTestCli().parse(
-                listOf(
-                    "--platform", "android",
-                    "--build-system", "ndk-build",
-                    "--plugin-path", quxPath.toString(),
-                    "--output", "out",
+                    "--output", file.path,
                     fooPath.toString()
                 )
             )
@@ -163,7 +129,7 @@ class ArgParserTest {
                     "--ndk-version", "21",
                     "--build-system", "ndk-build",
                     "--output", "out",
-                    plug1.path
+                    file.path
                 )
             )
         }
@@ -196,8 +162,6 @@ class ArgParserTest {
                 "--ndk-version", "21",
                 "--build-system", "ndk-build",
                 "--output", "out",
-                "--plugin-path", plug1.path,
-                "--plugin-path", plug2.path,
                 fooPath.toString(),
                 quxPath.toString()
             )

--- a/cmake-plugin/src/main/kotlin/com/google/prefab/cmake/CMakePlugin.kt
+++ b/cmake-plugin/src/main/kotlin/com/google/prefab/cmake/CMakePlugin.kt
@@ -17,7 +17,6 @@
 package com.google.prefab.cmake
 
 import com.google.prefab.api.Android
-import com.google.prefab.api.BuildSystemFactory
 import com.google.prefab.api.BuildSystemInterface
 import com.google.prefab.api.LibraryReference
 import com.google.prefab.api.Module
@@ -173,19 +172,5 @@ class CMakePlugin(
             endif()
             """.trimIndent()
         )
-    }
-
-    /**
-     * The [CMakePlugin] factory object.
-     */
-    companion object : BuildSystemFactory {
-        override val identifier: String = "cmake"
-
-        override fun create(
-            outputDirectory: File,
-            packages: List<Package>
-        ): BuildSystemInterface {
-            return CMakePlugin(outputDirectory, packages)
-        }
     }
 }

--- a/cmake-plugin/src/main/kotlin/com/google/prefab/cmake/CMakePluginProvider.kt
+++ b/cmake-plugin/src/main/kotlin/com/google/prefab/cmake/CMakePluginProvider.kt
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2019 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.prefab.cmake
+
+import com.google.prefab.api.BuildSystemInterface
+import com.google.prefab.api.BuildSystemProvider
+import com.google.prefab.api.Package
+import java.io.File
+
+/**
+ * Service provider for the [CMakePlugin].
+ */
+class CMakePluginProvider : BuildSystemProvider {
+    override val identifier: String = "cmake"
+
+    override fun create(
+        outputDirectory: File,
+        packages: List<Package>
+    ): BuildSystemInterface {
+        return CMakePlugin(outputDirectory, packages)
+    }
+}

--- a/cmake-plugin/src/main/resources/META-INF/services/com.google.prefab.api.BuildSystemProvider
+++ b/cmake-plugin/src/main/resources/META-INF/services/com.google.prefab.api.BuildSystemProvider
@@ -1,0 +1,1 @@
+com.google.prefab.cmake.CMakePluginProvider

--- a/docs/build-systems.md
+++ b/docs/build-systems.md
@@ -3,9 +3,9 @@
 Prefab's primary task is generating the build system integrations needed to
 consume the modules a package describes. This support is provided by plugins for
 each build system. By default, Prefab includes and loads the plugins for [CMake]
-and [ndk-build]. Additional plugins can be provided at run-time with the
-`--plugin` option. For common build systems, please consider [contributing] your
-plugin to Prefab.
+and [ndk-build]. Additional plugins can be provided at run-time by adding them
+to the Java classpath. For common build systems, please consider [contributing]
+your plugin to Prefab.
 
 [CMake]: https://cmake.org/
 [contributing]: https://github.com/google/prefab/blob/master/CONTRIBUTING.md

--- a/docs/index.md
+++ b/docs/index.md
@@ -50,7 +50,6 @@ Android specific configuration options:
 Options:
   --build-system TEXT  Generate integration for the given build system.
   --output DIRECTORY   Output path for generated build system integration.
-  --plugin-path FILE   Path to build system integration plugin.
   --platform TEXT      Target platform. Only 'android' is currently supported.
   -h, --help           Show this message and exit
 ```

--- a/ndk-build-plugin/src/main/kotlin/com/google/prefab/ndkbuild/NdkBuildPlugin.kt
+++ b/ndk-build-plugin/src/main/kotlin/com/google/prefab/ndkbuild/NdkBuildPlugin.kt
@@ -17,7 +17,6 @@
 package com.google.prefab.ndkbuild
 
 import com.google.prefab.api.Android
-import com.google.prefab.api.BuildSystemFactory
 import com.google.prefab.api.BuildSystemInterface
 import com.google.prefab.api.LibraryReference
 import com.google.prefab.api.Module
@@ -231,18 +230,4 @@ class NdkBuildPlugin(
     } ?: throw RuntimeException(
         "Could not find a module matching $reference"
     )
-
-    /**
-     * The [NdkBuildPlugin] factory object.
-     */
-    companion object : BuildSystemFactory {
-        override val identifier: String = "ndk-build"
-
-        override fun create(
-            outputDirectory: File,
-            packages: List<Package>
-        ): BuildSystemInterface {
-            return NdkBuildPlugin(outputDirectory, packages)
-        }
-    }
 }

--- a/ndk-build-plugin/src/main/kotlin/com/google/prefab/ndkbuild/NdkBuildPluginProvider.kt
+++ b/ndk-build-plugin/src/main/kotlin/com/google/prefab/ndkbuild/NdkBuildPluginProvider.kt
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2019 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.prefab.ndkbuild
+
+import com.google.prefab.api.BuildSystemInterface
+import com.google.prefab.api.BuildSystemProvider
+import com.google.prefab.api.Package
+import java.io.File
+
+/**
+ * Service provider for the [NdkBuildPlugin].
+ */
+class NdkBuildPluginProvider : BuildSystemProvider {
+    override val identifier: String = "ndk-build"
+
+    override fun create(
+        outputDirectory: File,
+        packages: List<Package>
+    ): BuildSystemInterface {
+        return NdkBuildPlugin(outputDirectory, packages)
+    }
+}

--- a/ndk-build-plugin/src/main/resources/META-INF/services/com.google.prefab.api.BuildSystemProvider
+++ b/ndk-build-plugin/src/main/resources/META-INF/services/com.google.prefab.api.BuildSystemProvider
@@ -1,0 +1,1 @@
+com.google.prefab.ndkbuild.NdkBuildPluginProvider


### PR DESCRIPTION
Rather than having these be passed as `--plugin-path` on the
command-line, which requires more complicated testing and a separate
code path for built-in plugins as compared to user loaded, just load
all plugins available on the classpath, and load the default ndk-build
and CMake plugins that way rather than explicitly loading them.
    
Users that want to load their own plugins will need to modify the Java
command line to include their own plugin JARs in the classpath.
    
Fixes https://github.com/google/prefab/issues/22