### PR TITLE
Infer version qualifier from the tag name.

### DIFF
--- a/.cloudbuild/release.yaml
+++ b/.cloudbuild/release.yaml
@@ -1,6 +1,6 @@
 steps:
 - name: 'gcr.io/cloud-builders/gradle:5.6.2-jdk-8'
-  args: ['--stacktrace', '-Pprefab.release', 'release']
+  args: ['--stacktrace', '-Pprefab.tagName=$TAG_NAME', 'release']
 artifacts:
   objects:
     location: 'gs://$_ARTIFACT_BUCKET/$PROJECT_ID/$TAG_NAME'


### PR DESCRIPTION
We shouldn't be deleting tags that have been pushed to GitHub, so if we want to test a release build before blessing it as the final build of that version it needs to be tagged as a non-final release first. This patch gives us the following release workflow:

1. Tag the pre-release commit with v1.0.0-rc1 (or whatever tag is appropriate for the given build).
2. Test the build as needed.
3. If issues are found, fix and release another pre-release as v1.0.0-rc2 and so on until ready for final release.
4. Re-tag the stabilized pre-release commit as v1.0.0 (the commit will be referred to by v1.0.0 and at least one pre-release tag).
5. Ship the v1.0.0 tagged build.
6. Update the baseVersion in the build.gradle.kts for the next release.

This is closer to how I'd originally implemented our release builds. @jmgao shot that down because he was concerned about the reproducibility of builds, since the behavior of the build would change based on the tag. We can reproduce an tagged build as needed with Cloud Build because there's a "rebuild" option for a given build. The alternative would be to encode the qualifier in the build.gradle.kts as well, but this means that more than one commit could produce the same version, which seems undesirable. @jmgao any objections/suggestions for this?

When parsing the tag, I currently verify that the version in the tag matches the version that would be used for non-tagged (snapshot) builds. Alternatively, I could just use the version parsed from the tag and ignore the value in the build.gradle. This might be nicer because it would allow us to set the snapshot version to something less precise like "1.0-SNAPSHOT" or even "1-SNAPSHOT" so we don't have to maintain the version in the build.gradle except when we make major changes.

/gcbrun