### PR TITLE
Fix service definition in the CLI fat JAR.

### DIFF
--- a/cli/src/main/resources/META-INF/services/com.google.prefab.api.BuildSystemProvider
+++ b/cli/src/main/resources/META-INF/services/com.google.prefab.api.BuildSystemProvider
@@ -1,1 +1,2 @@
+com.google.prefab.cmake.CMakePluginProvider
 com.google.prefab.ndkbuild.NdkBuildPluginProvider

--- a/cmake-plugin/src/main/resources/META-INF/services/com.google.prefab.api.BuildSystemProvider
+++ b/cmake-plugin/src/main/resources/META-INF/services/com.google.prefab.api.BuildSystemProvider
@@ -1,1 +1,0 @@
-com.google.prefab.cmake.CMakePluginProvider


### PR DESCRIPTION
The JAR was getting multiple entries for the same file which resulted
in only one plugin being visible. Ideally they would be merged, but
I'm not sure how to do that in Gradle, so for now just move the
service provider metadata into the CLI package since we don't need the
build plugins to work separately anyway.