### PR TITLE
Don't publish the ndk-build or CMake plugins.

### DIFF
--- a/api/build.gradle.kts
+++ b/api/build.gradle.kts
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 
+extra["publish"] = true
 extra["pomName"] = "Prefab Plugin API"
 extra["pomDescription"] = "The API for Prefab plugins."
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -82,44 +82,48 @@ subprojects {
     }
 
     afterEvaluate {
-        publishing {
-            publications {
-                create<MavenPublication>("default") {
-                    from(components["java"])
+        if (extra["publish"] as Boolean) {
+            publishing {
+                publications {
+                    create<MavenPublication>("default") {
+                        from(components["java"])
 
-                    pom {
-                        name.set(extra["pomName"] as String)
-                        description.set(extra["pomDescription"] as String)
-                        url.set("https://google.github.io/prefab/")
-                        licenses {
-                            license {
-                                name.set("Apache License, Version 2.0")
-                                url.set(
-                                    "http://www.apache.org/licenses/LICENSE-2.0.txt"
-                                )
-                                distribution.set("repo")
+                        pom {
+                            name.set(extra["pomName"] as String)
+                            description.set(extra["pomDescription"] as String)
+                            url.set("https://google.github.io/prefab/")
+                            licenses {
+                                license {
+                                    name.set("Apache License, Version 2.0")
+                                    url.set(
+                                        "http://www.apache.org/licenses/LICENSE-2.0.txt"
+                                    )
+                                    distribution.set("repo")
+                                }
                             }
-                        }
-                        scm {
-                            connection.set(
-                                "scm:git:https://github.com/google/prefab.git"
-                            )
-                            developerConnection.set(
-                                "scm:git:git@github.com:google/prefab.git"
-                            )
-                            url.set("https://github.com/google/prefab")
-                        }
-                        issueManagement {
-                            system.set("GitHub")
-                            url.set("https://github.com/google/prefab/issues")
+                            scm {
+                                connection.set(
+                                    "scm:git:https://github.com/google/prefab.git"
+                                )
+                                developerConnection.set(
+                                    "scm:git:git@github.com:google/prefab.git"
+                                )
+                                url.set("https://github.com/google/prefab")
+                            }
+                            issueManagement {
+                                system.set("GitHub")
+                                url.set(
+                                    "https://github.com/google/prefab/issues"
+                                )
+                            }
                         }
                     }
                 }
-            }
 
-            repositories {
-                maven {
-                    url = uri("${rootProject.buildDir}/repository")
+                repositories {
+                    maven {
+                        url = uri("${rootProject.buildDir}/repository")
+                    }
                 }
             }
         }

--- a/cli/build.gradle.kts
+++ b/cli/build.gradle.kts
@@ -18,6 +18,7 @@ plugins {
     application
 }
 
+extra["publish"] = true
 extra["pomName"] = "Prefab"
 extra["pomDescription"] = "The main Prefab program."
 

--- a/cmake-plugin/build.gradle.kts
+++ b/cmake-plugin/build.gradle.kts
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 
+extra["publish"] = false
 extra["pomName"] = "Prefab CMake Plugin"
 extra["pomDescription"] = "The Prefab CMake build plugin."
 

--- a/ndk-build-plugin/build.gradle.kts
+++ b/ndk-build-plugin/build.gradle.kts
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 
+extra["publish"] = false
 extra["pomName"] = "Prefab ndk-build Plugin"
 extra["pomDescription"] = "The Prefab ndk-build plugin."
 


### PR DESCRIPTION
These aren't tested to work if distributed separately of the CLI fat
JAR, so avoid publishing them until we need to.