### PR TITLE
Use the shadow plugin to create the fat JAR.

### DIFF
--- a/api/build.gradle.kts
+++ b/api/build.gradle.kts
@@ -14,11 +14,40 @@
  * limitations under the License.
  */
 
-extra["publish"] = true
-extra["pomName"] = "Prefab Plugin API"
-extra["pomDescription"] = "The API for Prefab plugins."
-
 dependencies {
     api("org.jetbrains.kotlinx:kotlinx-serialization-runtime:0.13.0")
     testImplementation("io.mockk:mockk:1.9.3")
+}
+
+publishing {
+    publications {
+        create<MavenPublication>("default") {
+            from(components["java"])
+
+            pom {
+                name.set("Prefab Plugin API")
+                description.set("The API for Prefab plugins.")
+                url.set(rootProject.property("prefab.pom.url") as String)
+                licenses {
+                    license {
+                        name.set(
+                            rootProject.property(
+                                "prefab.pom.licenseName"
+                            ) as String
+                        )
+                        url.set(
+                            rootProject.property(
+                                "prefab.pom.licenseUrl"
+                            ) as String
+                        )
+                        distribution.set(
+                            rootProject.property(
+                                "prefab.pom.licenseDistribution"
+                            ) as String
+                        )
+                    }
+                }
+            }
+        }
+    }
 }

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -72,6 +72,14 @@ subprojects {
         testRuntimeOnly("org.junit.jupiter:junit-jupiter-engine:5.6.0-M1")
     }
 
+    publishing {
+        repositories {
+            maven {
+                url = uri("${rootProject.buildDir}/repository")
+            }
+        }
+    }
+
     tasks.withType<KotlinCompile> {
         kotlinOptions.jvmTarget = "1.8"
         kotlinOptions.allWarningsAsErrors = true
@@ -79,54 +87,6 @@ subprojects {
             "-progressive",
             "-Xuse-experimental=kotlinx.serialization.ImplicitReflectionSerializer"
         )
-    }
-
-    afterEvaluate {
-        if (extra["publish"] as Boolean) {
-            publishing {
-                publications {
-                    create<MavenPublication>("default") {
-                        from(components["java"])
-
-                        pom {
-                            name.set(extra["pomName"] as String)
-                            description.set(extra["pomDescription"] as String)
-                            url.set("https://google.github.io/prefab/")
-                            licenses {
-                                license {
-                                    name.set("Apache License, Version 2.0")
-                                    url.set(
-                                        "http://www.apache.org/licenses/LICENSE-2.0.txt"
-                                    )
-                                    distribution.set("repo")
-                                }
-                            }
-                            scm {
-                                connection.set(
-                                    "scm:git:https://github.com/google/prefab.git"
-                                )
-                                developerConnection.set(
-                                    "scm:git:git@github.com:google/prefab.git"
-                                )
-                                url.set("https://github.com/google/prefab")
-                            }
-                            issueManagement {
-                                system.set("GitHub")
-                                url.set(
-                                    "https://github.com/google/prefab/issues"
-                                )
-                            }
-                        }
-                    }
-                }
-
-                repositories {
-                    maven {
-                        url = uri("${rootProject.buildDir}/repository")
-                    }
-                }
-            }
-        }
     }
 }
 

--- a/cmake-plugin/build.gradle.kts
+++ b/cmake-plugin/build.gradle.kts
@@ -14,10 +14,6 @@
  * limitations under the License.
  */
 
-extra["publish"] = false
-extra["pomName"] = "Prefab CMake Plugin"
-extra["pomDescription"] = "The Prefab CMake build plugin."
-
 dependencies {
     api(project(":api"))
 }

--- a/cmake-plugin/src/main/resources/META-INF/services/com.google.prefab.api.BuildSystemProvider
+++ b/cmake-plugin/src/main/resources/META-INF/services/com.google.prefab.api.BuildSystemProvider
@@ -1,0 +1,1 @@
+com.google.prefab.cmake.CMakePluginProvider

--- a/gradle.properties
+++ b/gradle.properties
@@ -16,3 +16,10 @@
 
 prefab.version = 1.0.0
 prefab.qualifier =
+
+prefab.pom.url = https://google.github.io/prefab/
+prefab.pom.licenseName = Apache License, Version 2.0
+prefab.pom.licenseUrl = http://www.apache.org/licenses/LICENSE-2.0.txt
+prefab.pom.licenseDistribution = repo
+
+

--- a/ndk-build-plugin/build.gradle.kts
+++ b/ndk-build-plugin/build.gradle.kts
@@ -14,10 +14,6 @@
  * limitations under the License.
  */
 
-extra["publish"] = false
-extra["pomName"] = "Prefab ndk-build Plugin"
-extra["pomDescription"] = "The Prefab ndk-build plugin."
-
 dependencies {
     api(project(":api"))
 }

--- a/ndk-build-plugin/src/main/resources/META-INF/services/com.google.prefab.api.BuildSystemProvider
+++ b/ndk-build-plugin/src/main/resources/META-INF/services/com.google.prefab.api.BuildSystemProvider
@@ -1,2 +1,1 @@
-com.google.prefab.cmake.CMakePluginProvider
 com.google.prefab.ndkbuild.NdkBuildPluginProvider


### PR DESCRIPTION
The way I'd previously done this left all of the dependencies stated
in the POM even though they were included in the JAR. The shadow
plugin appears to be quite widely used and does a better job of
building fat JARs.

This also conveniently deals with the merging of service files for us,
so I've reverted the changes in
https://github.com/google/prefab/pull/36 and used that instead, and
similarly merged our NOTICE files (they're all currently identical,
but this future-proofs it).

Since the two publication configurations have now diverged quite a
bit, I removed them from the common build.gradle.kts and defined each
in their own build files. The common components have been moved to
gradle properties.

/gcbrun