### PR TITLE
Change the fat JAR packaging from POM to JAR.

### DIFF
--- a/cli/build.gradle.kts
+++ b/cli/build.gradle.kts
@@ -59,6 +59,7 @@ publishing {
                 name.set("Prefab")
                 description.set("The main Prefab program.")
                 url.set(rootProject.property("prefab.pom.url") as String)
+                packaging = "jar"
                 licenses {
                     license {
                         name.set(


### PR DESCRIPTION
It seems like the default packaging attribute is incorrect. POM should
be used when there are explicit submodules that the artifact refers
to, which is not the case for a fat JAR.

I'm not sure if this is the right fix for the artifact not being usable from within Studio's bazel build yet (waiting to hear back from London).

/gcbrun