### PR TITLE
Require config packages in CMake.

### DIFF
--- a/cli/src/test/kotlin/com/google/prefab/cli/CMakePluginTest.kt
+++ b/cli/src/test/kotlin/com/google/prefab/cli/CMakePluginTest.kt
@@ -101,9 +101,9 @@ class CMakePluginTest {
         val bazDir = fooPath.resolve("modules/baz").sanitize()
         assertEquals(
             """
-            find_package(quux REQUIRED)
+            find_package(quux REQUIRED CONFIG)
 
-            find_package(qux REQUIRED)
+            find_package(qux REQUIRED CONFIG)
 
             add_library(foo::bar SHARED IMPORTED)
             set_target_properties(foo::bar PROPERTIES
@@ -140,7 +140,7 @@ class CMakePluginTest {
         val quxDir = quxPath.resolve("modules/libqux").sanitize()
         assertEquals(
             """
-            find_package(foo REQUIRED)
+            find_package(foo REQUIRED CONFIG)
 
             add_library(qux::libqux SHARED IMPORTED)
             set_target_properties(qux::libqux PROPERTIES

--- a/cmake-plugin/src/main/kotlin/com/google/prefab/cmake/CMakePlugin.kt
+++ b/cmake-plugin/src/main/kotlin/com/google/prefab/cmake/CMakePlugin.kt
@@ -99,7 +99,7 @@ class CMakePlugin(
     private fun emitDependency(dep: String, configFile: File) {
         configFile.appendText(
             """
-            find_package($dep REQUIRED)
+            find_package($dep REQUIRED CONFIG)
 
 
         """.trimIndent()


### PR DESCRIPTION
If the system has a Find$DEP.cmake available, CMake might prefer that
definition to ours. It almost certainly won't contain libraries for
Android, and it may not even expose the same interface. It may not
necessarily find *any* libraries at all.

Enforce that a config-style package is loaded rather than the
module-style package (see
https://cmake.org/cmake/help/latest/command/find_package.html).

/gcbrun