### PR TITLE
Add instructions for building CLI executable

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,3 +21,8 @@ prebuilt libraries it describes. Prefab is:
 [Build system agnostic]: https://google.github.io/prefab/build-systems.html
 [Cross-platform]: https://google.github.io/prefab/platform-support.html
 [metadata]: https://google.github.io/prefab/#metadata
+
+## Building the command line executable
+
+From the prefab directory run `./gradlew installDist`. This will build and
+install the CLI binary (named `cli`) into  `cli/build/install/cli`.


### PR DESCRIPTION
Related: https://github.com/google/prefab/issues/60