### PR TITLE
Fix path matcher in Android STL checker.

### DIFF
--- a/api/src/main/kotlin/com/google/prefab/api/Android.kt
+++ b/api/src/main/kotlin/com/google/prefab/api/Android.kt
@@ -218,7 +218,7 @@ class Android(val abi: Abi, api: Int, val stl: Stl, val ndkMajorVersion: Int) :
         }
 
         val pathMatcher = library.path.fileSystem.getPathMatcher("glob:*.a")
-        if (pathMatcher.matches(library.path)) {
+        if (pathMatcher.matches(library.path.fileName)) {
             // The dependency is a static library, so its choice of static or
             // shared STL is not actually meaningful; it'll use whatever the
             // user uses. No further checking required.

--- a/api/src/test/kotlin/com/google/prefab/api/AndroidTest.kt
+++ b/api/src/test/kotlin/com/google/prefab/api/AndroidTest.kt
@@ -82,32 +82,32 @@ class AndroidTest {
         // A shared library using c++_shared.
         val cxxSharedSharedLib = mockk<PrebuiltLibrary>()
         every { cxxSharedSharedLib.platform } returns cxxShared
-        every { cxxSharedSharedLib.path } returns Paths.get("libfoo.so")
+        every { cxxSharedSharedLib.path } returns Paths.get("libs/libfoo.so")
 
         // A static library using c++_shared.
         val cxxSharedStaticLib = mockk<PrebuiltLibrary>()
         every { cxxSharedStaticLib.platform } returns cxxShared
-        every { cxxSharedStaticLib.path } returns Paths.get("libfoo.a")
+        every { cxxSharedStaticLib.path } returns Paths.get("libs/libfoo.a")
 
         // A shared library using c++_static.
         val cxxStaticSharedLib = mockk<PrebuiltLibrary>()
         every { cxxStaticSharedLib.platform } returns cxxStatic
-        every { cxxStaticSharedLib.path } returns Paths.get("libfoo.so")
+        every { cxxStaticSharedLib.path } returns Paths.get("libs/libfoo.so")
 
         // A static library using c++_static.
         val cxxStaticStaticLib = mockk<PrebuiltLibrary>()
         every { cxxStaticStaticLib.platform } returns cxxStatic
-        every { cxxStaticStaticLib.path } returns Paths.get("libfoo.a")
+        every { cxxStaticStaticLib.path } returns Paths.get("libs/libfoo.a")
 
         // A shared library using gnustl_shared.
         val gnuSharedSharedLib = mockk<PrebuiltLibrary>()
         every { gnuSharedSharedLib.platform } returns gnuShared
-        every { gnuSharedSharedLib.path } returns Paths.get("libfoo.so")
+        every { gnuSharedSharedLib.path } returns Paths.get("libs/libfoo.so")
 
         // A shared library using gnustl_static.
         val gnuSharedStaticLib = mockk<PrebuiltLibrary>()
         every { gnuSharedStaticLib.platform } returns gnuShared
-        every { gnuSharedStaticLib.path } returns Paths.get("libfoo.a")
+        every { gnuSharedStaticLib.path } returns Paths.get("libs/libfoo.a")
 
         // A library using no STL.
         val noneLib = mockk<PrebuiltLibrary>()


### PR DESCRIPTION
https://docs.oracle.com/javase/10/docs/api/java/nio/file/FileSystem.html#getPathMatcher(java.lang.String)

> The * character matches zero or more characters of a name component
> **without crossing directory boundaries.**

/gcbrun