### PR TITLE
Fix most doc TODOs.

### DIFF
--- a/api/src/main/kotlin/com/google/prefab/api/Android.kt
+++ b/api/src/main/kotlin/com/google/prefab/api/Android.kt
@@ -272,6 +272,13 @@ class Android(val abi: Abi, api: Int, val stl: Stl, val ndkMajorVersion: Int) :
         }
 
         return stlsAreCompatible(library)
+
+        // TODO: Check for ABI boundaries across NDK major versions.
+        // At present the only known ABI break in the NDK was when the libc++
+        // ABI changed in r11. No one should actually use libc++ in either of
+        // those releases, nor should they be using those releases any more, so
+        // this isn't an urgent check to add. If we introduce more ABI breaks in
+        // the future we'll want to make sure we add checks for those.
     }
 
     override fun findBestMatch(

--- a/docs/index.md
+++ b/docs/index.md
@@ -24,15 +24,15 @@ prebuilt libraries it describes. Prefab is:
 
 ## Usage
 
-Note: The Android Gradle Plugin natively supports Prefab packages. See TODO for
-more information.
+Note: The Android Gradle Plugin natively supports Prefab packages. See the
+[New Features in Android Studio] page for more information.
+
+[New Features in Android Studio]: https://developer.android.com/studio/preview/features#native-dependencies
 
 Prefab is a command line tool the operates on the packages described in this
 document. At least one package path must be given, and each package path should
 point to the directory structure described in [Package
 Structure](#package-structure).
-
-TODO: Improve usage message.
 
 ```text
 Usage: prefab [OPTIONS] PACKAGE_PATH...
@@ -54,11 +54,28 @@ Options:
   -h, --help           Show this message and exit
 ```
 
-TODO: Example.
+For example, if your app is using CMake, c++_shared, NDK r21, and has a
+minSdkVersion of 21, you can generate [CMake packages] for your dependencies in
+the `deps` directory with the following commands:
 
-## Authoring
+```bash
+$ prefab --output out/arm64-v8a --build-system cmake --platform android \
+    --abi arm64-v8a --os-version 21 --ndk-version 21 --stl c++_shared deps
+$ prefab --output out/armeabi-v7a --build-system cmake --platform android \
+    --abi armeabi-v7a --os-version 21 --ndk-version 21 --stl c++_shared deps
+$ prefab --output out/x86 --build-system cmake --platform android \
+    --abi x86 --os-version 21 --ndk-version 21 --stl c++_shared deps
+$ prefab --output out/x86_64 --build-system cmake --platform android \
+    --abi x86_64 --os-version 21 --ndk-version 21 --stl c++_shared deps
+```
 
-TODO: Write authoring guide.
+This generates [CMake packages] that can be imported into your build with
+[find_package]. See the [Build System Support in Prefab] page for more
+information.
+
+[CMake packages]: https://cmake.org/cmake/help/latest/manual/cmake-packages.7.html
+[find_package]: https://cmake.org/cmake/help/latest/command/find_package.html
+[Build System Support in Prefab]: build-systems.md
 
 ## Package Structure {#package-structure}
 
@@ -114,7 +131,9 @@ The include directory within each platform's library directory is optional. If
 present, that include path will be used instead of the module headers for that
 platform.
 
-TODO: Example.
+For examples, see the [test packages] in the source.
+
+[test packages]: https://github.com/google/prefab/tree/master/cli/src/test/resources/com/google/prefab/cli/packages
 
 ## Metadata {#metadata}
 
@@ -158,7 +177,7 @@ version 1.1.1a should be written as 1.1.1.1.
 Package's `name`) that this Package depends on. All dependent packages must be
 available to Prefab during build script generation.
 
-TODO: Example.
+For examples, see the prefab.json files in the [test packages].
 
 ### Module Metadata {#module-metadata}
 
@@ -191,7 +210,6 @@ intra-package references, or inter-package references.
 | `:foo`      | Consumers will link the `foo` module from this package.      |
 | `//bar:baz` | Consumers will link the `baz` module from the `bar` package. |
 
-TODO: Verify.
 Note that, except for the first case, the headers for the modules will also be
 made available to the consuming package.
 
@@ -204,4 +222,4 @@ overridden dependening on the target platform. Each subfield follows the same
 rules of the main properties with the same name. If specified, the
 platform-specific properties override the generic properties.
 
-TODO: Example.
+For examples, see the module.json files in the [test packages].

--- a/docs/platform-support.md
+++ b/docs/platform-support.md
@@ -26,17 +26,18 @@ split into the following packages:
 ## Supported Platforms
 
 At present, only Android targets are supported. Support for desktop Linux is a
-work in progress (TODO: send PR and link), with some outstanding questions about
-exactly what constraints need to be defined for that platform. [Patches] to
-support additional targets are welcome. Unlike build system support, platform
-support cannot be provided as a plugin and must be directly implemented in
-Prefab. This is to avoid the fragmentation of packages that would occur if there
-were multiple implementations of support for a given platform. For example, if
-there were both an `ubuntu` and a `linux-ubuntu` plugin with libraries that are
+[work in progress], with some outstanding questions about exactly what
+constraints need to be defined for that platform. [Patches] to support
+additional targets are welcome. Unlike build system support, platform support
+cannot be provided as a plugin and must be directly implemented in Prefab. This
+is to avoid the fragmentation of packages that would occur if there were
+multiple implementations of support for a given platform. For example, if there
+were both an `ubuntu` and a `linux-ubuntu` plugin with libraries that are
 compatible, their packages would not be mutually usable. Keeping platform
 support centralized avoids this issue.
 
 [Patches]: https://github.com/google/prefab/blob/master/CONTRIBUTING.md
+[work in progress]: https://github.com/google/prefab/pull/90
 
 ### Android
 
@@ -61,8 +62,6 @@ the requested configuration:
 2. API for a dependency cannot be higher than `--os-version`.
 3. STLs must be compatible as defined by
    `com.google.prefab.api.Android::stlsAreCompatible`.
-
-TODO: Implement NDK version ABI boundary checks.
 
 ## Platform API
 


### PR DESCRIPTION
I've removed the TODO for the authoring guide. I don't think we can
usefully write an authoring guide that isn't Android specific beyond
what's already documented.

There are still TODOs to get the javadoc hosted somewhere, but I
haven't sorted that process out yet.