### PR TITLE
Bump next version to 1.2.0.

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -14,7 +14,7 @@
 # limitations under the License.
 # 
 
-prefab.version = 1.0.0
+prefab.version = 1.2.0
 prefab.qualifier =
 
 prefab.pom.url = https://google.github.io/prefab/


### PR DESCRIPTION
Forgot to upload the similar change for 1.1.0. All the snapshot builds
after 1.1.0 (which was actually only one build) were 1.0.0-SNAPSHOT
instead of 1.1.0-SNAPSHOT.