### PR TITLE
Fix Java 8 compatibility.

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -82,6 +82,12 @@ subprojects {
         kotlinOptions.jvmTarget = "1.8"
         kotlinOptions.allWarningsAsErrors = true
     }
+
+    java {
+        toolchain {
+            languageVersion.set(JavaLanguageVersion.of(8))
+        }
+    }
 }
 
 tasks.withType<org.jetbrains.dokka.gradle.DokkaTask>().configureEach {


### PR DESCRIPTION
I think this is only fixing the declaration in the gradle module
properties since the Kotlin compiler was already configured for 1.8
and we don't (directly) use any Java, but the gradle module properties
certainly think we're using Java 11 without this.