### PR TITLE
Fix Java toolchain requirement.

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -84,9 +84,7 @@ subprojects {
     }
 
     java {
-        toolchain {
-            languageVersion.set(JavaLanguageVersion.of(8))
-        }
+        targetCompatibility = JavaVersion.VERSION_1_8
     }
 }
 


### PR DESCRIPTION
We don't need (or want) JDK 8, we just need the output to be compatible with JRE 8 (though even that's debatable and we should figure out what a reasonable minimum Java version is these days).

Fixes https://github.com/google/prefab/issues/166.