### PR TITLE
Fix missing -all JAR suffix.

### DIFF
--- a/cli/build.gradle.kts
+++ b/cli/build.gradle.kts
@@ -19,7 +19,7 @@ import com.github.jengelman.gradle.plugins.shadow.tasks.ShadowJar
 
 plugins {
     application
-    id("com.github.johnrengelman.shadow").version("8.1.1")
+    id("com.github.johnrengelman.shadow").version("8.1.0")
 }
 dependencies {
     implementation("com.github.ajalt.clikt:clikt:4.2.2")


### PR DESCRIPTION
https://github.com/johnrengelman/shadow/issues/860 says this is a bug in shadow 8.1.1. Revert to 8.1.0 until there's a fix available.